### PR TITLE
The error "the value of the parameter 'k' (declared at line 183) cannot be used as a constant Update apriori.cpp

### DIFF
--- a/apriori.cpp
+++ b/apriori.cpp
@@ -180,10 +180,12 @@ void subsetHash(SuperItemSet &ret,struct HashTree *head,vector<int> arr,int data
 }
  
 /*  Function to print the subset  */ 
-void genSubset(SuperItemSet &ret,struct HashTree *head,vector<int> arr,int n,int k){
-    int data[k];
-    subsetHash(ret,head,arr,data,0,n-1,0,k);
+void genSubset(SuperItemSet &ret, struct HashTree *head, vector<int> arr, int n, int k) {
+    std::vector<int> data(k);
+    subsetHash(ret, head, arr, data.data(), 0, n - 1, 0, k);
+    // No need to delete anything; vector takes care of memory management
 }
+
 
 SuperItemSet supportCount(struct HashTree *head,int k){
 	SuperItemSet ret;


### PR DESCRIPTION
occur because due to use a variable as the size of an array declaration. Array sizes must be constant expressions known at compile time .To resolve this issue, used dynamic memory allocation using std::vector 